### PR TITLE
Replace num BigInt with rug library for better API and performance

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/elgamal_capsule.iml
+++ b/.idea/elgamal_capsule.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/elgamal_capsule.iml" filepath="$PROJECT_DIR$/.idea/elgamal_capsule.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,4 @@ edition = "2021"
 
 [dependencies]
 encoding = "0.2.33"
-num = { version = "0.3.1", features = ["rand"] }
-mt19937 = "2.0.1"
-rand = { version = "0.6", default-features = false, optional = true }
-rand_core = { version = "0.6", features = ["std"] }
+rug = {version = "1.14.1" }


### PR DESCRIPTION
1. use rug (GDM) instead of num BigInt.
2. remove redundant code and improve code style.
3. create unit test for public key generation and encryption/decryption.