### PR TITLE
add safe prime and benchmark

### DIFF
--- a/.idea/elgamal_capsule.iml
+++ b/.idea/elgamal_capsule.iml
@@ -2,6 +2,7 @@
 <module type="CPP_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/benches" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,10 @@ edition = "2021"
 [dependencies]
 encoding = "0.2.33"
 rug = {version = "1.14.1" }
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "pubkey_benchmark"
+harness = false

--- a/benches/pubkey_benchmark.rs
+++ b/benches/pubkey_benchmark.rs
@@ -1,0 +1,34 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use elgamal_capsule::elgamal::generate_pub_key;
+use rug::rand::RandState;
+use rug::Integer;
+use std::time::Duration;
+
+fn pubkey_gen_benchmark(bit_length: u32) {
+    let mut rand = RandState::new_mersenne_twister();
+    for i in 1..10 {
+        let seed = Integer::from(i as i32);
+        rand.seed(&seed);
+        generate_pub_key(&mut rand, bit_length);
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sample-size-example");
+    group
+        .significance_level(0.1)
+        .measurement_time(Duration::from_secs(20));
+    group.bench_function("pubkey gen small x10", |b| {
+        b.iter(|| pubkey_gen_benchmark(64))
+    });
+    group.bench_function("pubkey gen middle x10", |b| {
+        b.iter(|| pubkey_gen_benchmark(128))
+    });
+    group.bench_function("pubkey gen big x10", |b| {
+        b.iter(|| pubkey_gen_benchmark(196))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
1. add safe prime to elgamal with rug.
2. add benchmark code with results:
sample-size-example/pubkey gen small 64 bit x10                                                                             
                        time:   [8.6476 ms 8.6733 ms 8.7042 ms]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
sample-size-example/pubkey gen middle 128 bit x10                                                                             
                        time:   [13.877 ms 13.912 ms 13.952 ms]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
sample-size-example/pubkey gen big 196 bit x10                                                                            
                        time:   [171.56 ms 171.91 ms 172.29 ms]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe